### PR TITLE
Method to retrieve database product name form database connection metadata

### DIFF
--- a/components/org.wso2.carbon.database.utils/pom.xml
+++ b/components/org.wso2.carbon.database.utils/pom.xml
@@ -60,8 +60,8 @@
             <artifactId>powermock-api-mockito</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
 
         <!--OSGi-->

--- a/components/org.wso2.carbon.database.utils/src/main/java/org/wso2/carbon/database/utils/jdbc/JdbcTemplate.java
+++ b/components/org.wso2.carbon.database.utils/src/main/java/org/wso2/carbon/database/utils/jdbc/JdbcTemplate.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.database.utils.jdbc;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
@@ -44,7 +44,8 @@ public class JdbcTemplate {
 
     private static final Logger log = LoggerFactory.getLogger(JdbcTemplate.class);
     private static final String ID = "ID";
-    private static String driverName;
+    private String driverName;
+    private String productName;
     private DataSource dataSource;
 
     public JdbcTemplate(DataSource dataSource) {
@@ -341,7 +342,28 @@ public class JdbcTemplate {
             return driverName;
         } catch (SQLException e) {
             throw new DataAccessException(JdbcConstants.ErrorCodes.ERROR_CODE_GET_DB_TYPE.getErrorMessage(),
-                    JdbcConstants.ErrorCodes.ERROR_CODE_GET_DB_TYPE.getErrorCode(), e);
+                                          JdbcConstants.ErrorCodes.ERROR_CODE_GET_DB_TYPE.getErrorCode(), e);
+        }
+    }
+
+    /**
+     * Retrieve database product name from the data source.
+     *
+     * @return database product name from the data source.
+     * @throws DataAccessException if an error occurs while retrieving metadata from data source.
+     */
+    public String getDatabaseProductName() throws DataAccessException {
+
+        if (StringUtils.isNotBlank(productName)) {
+            return productName;
+        }
+
+        try (Connection connection = dataSource.getConnection()) {
+            productName = connection.getMetaData().getDatabaseProductName();
+            return productName;
+        } catch (SQLException e) {
+            throw new DataAccessException(JdbcConstants.ErrorCodes.ERROR_CODE_GET_DB_TYPE.getErrorMessage(),
+                                          JdbcConstants.ErrorCodes.ERROR_CODE_GET_DB_TYPE.getErrorCode(), e);
         }
     }
 

--- a/components/org.wso2.carbon.database.utils/src/test/java/org/wso2/carbon/database/utils/jdbc/JdbcTemplateTest.java
+++ b/components/org.wso2.carbon.database.utils/src/test/java/org/wso2/carbon/database/utils/jdbc/JdbcTemplateTest.java
@@ -517,4 +517,33 @@ public class JdbcTemplateTest extends PowerMockTestCase {
         }
         jdbcTemplate.getDriverName();
     }
+
+    @Test
+    public void testGetDatabaseProductName() throws Exception {
+
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(basicDataSource);
+        assertEquals(jdbcTemplate.getDatabaseProductName(), "H2");
+    }
+
+    @Test(expectedExceptions = DataAccessException.class)
+    public void testGetDatabaseProductNameWithErrorConnection() throws Exception {
+
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(mockedDataSource);
+        when(mockedDataSource.getConnection()).thenThrow(new SQLException());
+        jdbcTemplate.getDatabaseProductName();
+    }
+
+    @Test(dataProvider = "exceptionLevelProvider", expectedExceptions = DataAccessException.class)
+    public void testGetDatabaseProductNameWithException(int exceptionLevel) throws Exception {
+
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(mockedDataSource);
+        Connection connection = Mockito.spy(basicDataSource.getConnection());
+        when(mockedDataSource.getConnection()).thenReturn(connection);
+        if (exceptionLevel == 1) {
+            when(connection.getMetaData()).thenThrow(new SQLException());
+        } else if (exceptionLevel == 2) {
+            when(connection.getMetaData().getDatabaseProductName()).thenThrow(new SQLException());
+        }
+        jdbcTemplate.getDatabaseProductName();
+    }
 }

--- a/components/org.wso2.carbon.database.utils/src/test/java/org/wso2/carbon/database/utils/jdbc/JdbcTemplateTestUtils.java
+++ b/components/org.wso2.carbon.database.utils/src/test/java/org/wso2/carbon/database/utils/jdbc/JdbcTemplateTestUtils.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.database.utils.jdbc;
 
 import org.apache.commons.dbcp.BasicDataSource;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 import java.nio.file.Paths;
 import java.sql.Connection;

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons.lang3.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons.lang.version}</version>
+            </dependency>
 
             <!--OSGi-->
             <dependency>
@@ -224,6 +229,7 @@
         <powermock.version>1.6.6</powermock.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.lang3.version>3.0</commons.lang3.version>
+        <commons.lang.version>2.6</commons.lang.version>
 
         <carbon.utils.package.export.version>${carbon.utils.version}</carbon.utils.package.export.version>
         <javax.management.import.version.range>[0.0.0,1.0.0)</javax.management.import.version.range>


### PR DESCRIPTION
## Purpose
> `getDatabaseProductName` method is introduced to identify the database type as some DB flavors (eg: db2) doesn't return an identifier to identify the database type with `getDriverName` method