### PR TITLE
Add duplicate fields support for NamedPreparedStatement

### DIFF
--- a/components/org.wso2.carbon.database.utils/src/main/java/org/wso2/carbon/database/utils/jdbc/NamedPreparedStatement.java
+++ b/components/org.wso2.carbon.database.utils/src/main/java/org/wso2/carbon/database/utils/jdbc/NamedPreparedStatement.java
@@ -109,8 +109,8 @@ public class NamedPreparedStatement implements PreparedStatement {
      */
     public void setLong(String name, long value) throws SQLException {
 
-        if (getIndex(name) > 0) {
-            preparedStatement.setLong(getIndex(name), value);
+        for (int index : getIndexList(name)) {
+            preparedStatement.setLong(index, value);
         }
     }
 
@@ -123,8 +123,8 @@ public class NamedPreparedStatement implements PreparedStatement {
      */
     public void setInt(String name, int value) throws SQLException {
 
-        if (getIndex(name) > 0) {
-            preparedStatement.setInt(getIndex(name), value);
+        for (int index : getIndexList(name)) {
+            preparedStatement.setInt(index, value);
         }
     }
 
@@ -137,8 +137,8 @@ public class NamedPreparedStatement implements PreparedStatement {
      */
     public void setString(String name, String value) throws SQLException {
 
-        if (getIndex(name) > 0) {
-            preparedStatement.setString(getIndex(name), value);
+        for (int index : getIndexList(name)) {
+            preparedStatement.setString(index, value);
         }
     }
 
@@ -160,8 +160,8 @@ public class NamedPreparedStatement implements PreparedStatement {
 
     public void setObject(String name, Object value) throws SQLException {
 
-        if (getIndex(name) > 0) {
-            preparedStatement.setObject(getIndex(name), value);
+        for (int index : getIndexList(name)) {
+            preparedStatement.setObject(index, value);
         }
     }
 
@@ -175,14 +175,25 @@ public class NamedPreparedStatement implements PreparedStatement {
      */
     public void setTimeStamp(String name, Timestamp timestamp, Calendar calendar) throws SQLException {
 
-        if (getIndex(name) > 0) {
-            preparedStatement.setTimestamp(getIndex(name), timestamp, calendar);
+        for (int index : getIndexList(name)) {
+            preparedStatement.setTimestamp(index, timestamp, calendar);
         }
     }
 
     private int getIndex(String name) {
 
         return fields.indexOf(name) + 1;
+    }
+
+    private List<Integer> getIndexList(String name) {
+
+        List<Integer> indexList = new ArrayList<>();
+        for (int index = 0; index < fields.size(); index++) {
+            if (fields.get(index).equals(name)) {
+                indexList.add(index + 1);
+            }
+        }
+        return indexList;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Add duplicate fields support for NamedPreparedStatement

If a SQL query has the same placeholder in multiple places assigning a value once will be enough.

As an example, the following query has `UM_TENANT_ID` in multiple places.

`SQL_QUERY = DELETE FROM UM_HYBRID_USER_ROLE WHERE UM_ROLE_ID=(SELECT UM_ID FROM UM_HYBRID_ROLE WHERE UM_ROLE_NAME=:UM_ROLE_NAME; AND UM_TENANT_ID=:UM_TENANT_ID;) AND UM_TENANT_ID=:UM_TENANT_ID;`

So now it will be enough to assign a value once for `UM_TENANT_ID` as below,
```
NamedPreparedStatement statement = new NamedPreparedStatement(connection, "SQL_QUERY")
statement.setString("UM_ROLE_NAME", "roleName");
statement.setInt("UM_TENANT_ID", tenantId);
```