### PR TITLE
Add Return Value to Named Template executeUpdate Method

### DIFF
--- a/components/org.wso2.carbon.database.utils/src/main/java/org/wso2/carbon/database/utils/jdbc/NamedTemplate.java
+++ b/components/org.wso2.carbon.database.utils/src/main/java/org/wso2/carbon/database/utils/jdbc/NamedTemplate.java
@@ -193,12 +193,13 @@ public class NamedTemplate<T> {
     }
 
     /**
-     * Executes the jdbc update query and returns nothing.
+     * Executes the jdbc update query and returns the result as updated id integer.
      *
      * @param query            SQL query with the parameter placeholders.
      * @param namedQueryFilter parameters for the SQL query parameter replacement.
+     * @return the updated id.
      */
-    public void executeUpdate(String query, NamedQueryFilter namedQueryFilter) throws DataAccessException {
+    public int executeUpdate(String query, NamedQueryFilter namedQueryFilter) throws DataAccessException {
 
         Connection connection = TransactionManager.getTransactionEntry().getConnection();
         try {
@@ -206,7 +207,7 @@ public class NamedTemplate<T> {
                 if (namedQueryFilter != null) {
                     namedQueryFilter.filter(namedPreparedStatement);
                 }
-                namedPreparedStatement.executeUpdate();
+                return namedPreparedStatement.executeUpdate();
             }
 
         } catch (SQLException e) {


### PR DESCRIPTION
## Purpose
Previously the `executeUpdate()` function in `NamedTemplate` class is implemented to return nothing. This has changed to return the number of affected rows, so that updated row count can be obtained in places where this function is called.

## Related Issues
- https://github.com/wso2/product-is/issues/12643

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/3788
- https://github.com/wso2/identity-api-server/pull/326
- https://github.com/wso2/product-is/pull/12644
- https://github.com/wso2-extensions/identity-conditional-auth-functions/pull/86
- https://github.com/wso2/product-is/pull/12655